### PR TITLE
Update Skimmer

### DIFF
--- a/src/HHbbVV/processors/bbVVSkimmer.py
+++ b/src/HHbbVV/processors/bbVVSkimmer.py
@@ -487,9 +487,9 @@ class bbVVSkimmer(processor.ProcessorABC):
                 key: val for key, val in skimmed_events.items() if key in self.min_branches
             }
 
-        ######################
+        #######################
         # Weights
-        ######################
+        #######################
 
         if isData:
             skimmed_events["weight"] = np.ones(n_events)


### PR DESCRIPTION
Updates needed:

 - [ ] Look at VBF lepton vetos (Andres)
 - [ ] Add PNet Wqq score for semi-resolved veto (Andres)
 - [x] Add VBF jets for vetos (Andres)
 - [ ] FSR/ISR for ttbar (Raghav)
 - [ ] electron, muon ID scale factors? add them as single weights (Cristina)
 - [x] Gen WW or ZZ info for HVV jets for WW -> ZZ extrapolation from nonresonant to resonant (Andres)
 - [ ] Fix scale weights for HH (No one)
 - [ ] Wait for next round of skimming
 - [ ] Run over single Hbb and HWW samples as well

Can be left for next time:

 - [ ] new LP SFs
 - [ ] new tagger?
 - [ ] update JMC?
 - [ ] pdf_weight and scalevar for XHY?
 - [ ] individual JECs
 - [ ] ttbar corrections?

