### PR TITLE
added cut to skimmer based on XHY->bbWW semi-resolved channel veto

### DIFF
--- a/src/HHbbVV/processors/bbVVSkimmer.py
+++ b/src/HHbbVV/processors/bbVVSkimmer.py
@@ -481,6 +481,18 @@ class bbVVSkimmer(processor.ProcessorABC):
             >= self.preselection["bbFatJetParticleNetMD_Txbb"]
         )
         add_selection("ak8bb_txbb", txbb_cut, *selection_args)
+        
+        # XHY->bbWW Semi-resolved Channel Veto
+        Wqq_excess = ak.count(fatjets["particleNet_H4qvsQCD"][fatjets["particleNet_H4qvsQCD"] >= 0.8],axis=-1 )  
+        
+        #if Wqq_excess for an event is == 2 then we need to make sure that the Hbb is included in these two
+        Wqq_cut = (
+            (Wqq_excess < 3) 
+            & ((Wqq_excess == 2 & ak8FatJetVars["ak8FatJetParticleNet_Th4q"][bb_mask] >= 0.8) 
+            | (Wqq_excess < 2))
+        ) 
+        
+        add_selection("ak8_semi_resolved_Wqq", Wqq_cut, *selection_args)
 
         # 2018 HEM cleaning
         # https://indico.cern.ch/event/1249623/contributions/5250491/attachments/2594272/4477699/HWW_0228_Draft.pdf

--- a/src/HHbbVV/processors/bbVVSkimmer.py
+++ b/src/HHbbVV/processors/bbVVSkimmer.py
@@ -481,17 +481,18 @@ class bbVVSkimmer(processor.ProcessorABC):
             >= self.preselection["bbFatJetParticleNetMD_Txbb"]
         )
         add_selection("ak8bb_txbb", txbb_cut, *selection_args)
-        
+
         # XHY->bbWW Semi-resolved Channel Veto
-        Wqq_excess = ak.count(fatjets["particleNet_H4qvsQCD"][fatjets["particleNet_H4qvsQCD"] >= 0.8],axis=-1 )  
-        
-        #if Wqq_excess for an event is == 2 then we need to make sure that the Hbb is included in these two
-        Wqq_cut = (
-            (Wqq_excess < 3) 
-            & ((Wqq_excess == 2 & ak8FatJetVars["ak8FatJetParticleNet_Th4q"][bb_mask] >= 0.8) 
-            | (Wqq_excess < 2))
-        ) 
-        
+        Wqq_excess = ak.count(
+            fatjets["particleNet_H4qvsQCD"][fatjets["particleNet_H4qvsQCD"] >= 0.8], axis=-1
+        )
+
+        # if Wqq_excess for an event is == 2 then we need to make sure that the Hbb is included in these two
+        Wqq_cut = (Wqq_excess < 3) & (
+            (Wqq_excess == 2 & ak8FatJetVars["ak8FatJetParticleNet_Th4q"][bb_mask] >= 0.8)
+            | (Wqq_excess < 2)
+        )
+
         add_selection("ak8_semi_resolved_Wqq", Wqq_cut, *selection_args)
 
         # 2018 HEM cleaning


### PR DESCRIPTION
The cut should remove any events that have 2 or more non-Hbb fatjets with Wqq scores above 0.8

Logic for cut: 
Compute number of fatjets per event with Wqq score > 0.8. Define cut as true for event if there are less than 3 such fatjets, and in the case that there are exactly two, define cut as true iff Hbb is one of them

To study this would I want to run over a large number of signal files (C2V = 0)? it seems like this cut is pretty rare from the several files that I tested. For background, would I use TTToSemiLeptonic as well?